### PR TITLE
fix bugs and add capabilities

### DIFF
--- a/src/main/mcp/conversion.ts
+++ b/src/main/mcp/conversion.ts
@@ -1,3 +1,56 @@
+export function wrapProgressTokenWithServer({
+  serverName,
+  progressToken,
+}: {
+  serverName: string;
+  progressToken: string | number;
+}): string {
+  return `${serverName}-${typeof progressToken}-${progressToken}`;
+}
+
+export function unwrapProgressToken({
+  progressToken,
+}: {
+  progressToken: string | number;
+}): {
+  serverName?: string;
+  progressToken: string | number;
+} {
+  // not wrapped
+  if (typeof progressToken !== "string") {
+    return {
+      progressToken,
+    };
+  }
+
+  const parts = progressToken.split("-");
+
+  // not wrapped
+  if (parts.length < 3) {
+    return {
+      progressToken,
+    };
+  }
+
+  const [serverName, progressTokenType] = parts;
+  const progressTokenValue = parts.slice(2).join("-");
+
+  try {
+    return {
+      serverName,
+      progressToken:
+        progressTokenType === "number"
+          ? Number(progressTokenValue)
+          : progressTokenValue,
+    };
+  } catch {
+    // not wrapped or invalid
+    return {
+      progressToken,
+    };
+  }
+}
+
 export function wrapUriWithServer({
   serverName,
   uri,

--- a/src/main/mcp/create-wrapper-mcp-server.ts
+++ b/src/main/mcp/create-wrapper-mcp-server.ts
@@ -1,4 +1,5 @@
 import { Configs } from "@/shared/schemas";
+import { G } from "@mobily/ts-belt";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import {
@@ -6,12 +7,15 @@ import {
   StdioClientTransport,
 } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import { ServerOptions } from "@modelcontextprotocol/sdk/server/index.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   CallToolRequestSchema,
   CallToolResult,
-  CancelledNotificationSchema,
+  CompleteRequestSchema,
+  CompleteResult,
+  CreateMessageRequestSchema,
+  CreateMessageResult,
+  EmptyResult,
   ErrorCode,
   GetPromptRequestSchema,
   GetPromptResult,
@@ -21,725 +25,517 @@ import {
   ListResourcesResult,
   ListResourceTemplatesRequestSchema,
   ListResourceTemplatesResult,
+  ListRootsRequestSchema,
+  ListRootsResult,
   ListToolsRequestSchema,
   ListToolsResult,
   McpError,
   ProgressNotificationSchema,
-  Prompt,
   PromptListChangedNotificationSchema,
   ReadResourceRequestSchema,
   ReadResourceResult,
-  Resource,
   ResourceListChangedNotificationSchema,
-  ResourceTemplate,
   ResourceUpdatedNotificationSchema,
   RootsListChangedNotificationSchema,
+  SetLevelRequestSchema,
   SubscribeRequestSchema,
-  Tool,
   ToolListChangedNotificationSchema,
   UnsubscribeRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import { unwrapUri, wrapUriWithServer } from "./conversion";
-
-const MAX_NAME_LENGTH = 64;
-
-function createUniqueName({
-  serverName,
-  name,
-  map,
-}: {
-  serverName: string;
-  name: string;
-  map: Map<string, unknown>;
-}): string | null {
-  // make a unique name
-  let uniqueName = `${serverName}-${name}`.substring(0, MAX_NAME_LENGTH);
-
-  let i = 1;
-  while (map.has(uniqueName)) {
-    // this is kind of ridiculous
-    if (i > 16) {
-      return null;
-    }
-
-    uniqueName = name + i;
-
-    // cut from the front to make sure that i isn't cut off
-    if (uniqueName.length > MAX_NAME_LENGTH) {
-      uniqueName = uniqueName.substring(uniqueName.length - MAX_NAME_LENGTH);
-    }
-
-    i++;
-  }
-
-  return uniqueName;
-}
-
-async function handleListResources(
-  clients: Map<string, Client>
-): Promise<ListResourcesResult> {
-  const allResources: Resource[] = [];
-
-  for (const [serverName, client] of clients) {
-    try {
-      const { resources } = await client.listResources();
-
-      for (const resource of resources) {
-        allResources.push({
-          ...resource,
-          uri: wrapUriWithServer({
-            serverName,
-            uri: resource.uri,
-          }),
-        });
-      }
-    } catch {
-      // ignore servers that do not support listing resources
-    }
-  }
-
-  return { resources: allResources };
-}
-
-async function handleListResourceTemplates(
-  clients: Map<string, Client>
-): Promise<ListResourceTemplatesResult> {
-  const allResourceTemplates: ResourceTemplate[] = [];
-
-  for (const [serverName, client] of clients) {
-    try {
-      const { resourceTemplates } = await client.listResourceTemplates();
-
-      for (const resourceTemplate of resourceTemplates) {
-        allResourceTemplates.push({
-          ...resourceTemplate,
-          uriTemplate: wrapUriWithServer({
-            serverName,
-            uri: resourceTemplate.uriTemplate,
-          }),
-        });
-      }
-    } catch {
-      // ignore servers that do not support listing resource templates
-    }
-  }
-
-  return { resourceTemplates: allResourceTemplates };
-}
+import { unwrapProgressToken, wrapUriWithServer } from "./conversion";
+import WrapperService from "./wrapper-service";
 
 export default async function createWrapperMcpServer({
   configs,
 }: {
   configs: Configs["mcp_servers"];
 }): Promise<McpServer> {
-  const onCloseHooks: (() => Promise<void>)[] = [];
+  // null until ALL clients are initialized
+  let service: WrapperService | null = null;
+
+  // used to keep track of functions that need to be called after clients are initialized
+  const postInitHooks: ((ensuredService: WrapperService) => Promise<void>)[] =
+    [];
+  let postInitHooksCalled = false;
+
+  const cleanupOnErrorHooks: (() => Promise<void>)[] = [];
+
   try {
-    // SETUP CLIENTS
-    const defaultEnv = getDefaultEnvironment();
-
-    const clients = new Map(
-      await Promise.all(
-        (configs ?? []).map(async (serverConfig): Promise<[string, Client]> => {
-          let client = new Client({
-            name: serverConfig.name,
-            version: "1.0.0",
-          });
-
-          if (serverConfig.kind === "command") {
-            const transport = new StdioClientTransport({
-              command: serverConfig.command,
-              args: serverConfig.args,
-              env: {
-                ...defaultEnv,
-                ...serverConfig.env,
-              },
-            });
-            onCloseHooks.push(() => transport.close());
-            onCloseHooks.push(() => client.close());
-            await client.connect(transport);
-          } else {
-            // try Streamable HTTP transport first
-            let transport:
-              | StreamableHTTPClientTransport
-              | SSEClientTransport
-              | null = null;
-            try {
-              transport = new StreamableHTTPClientTransport(
-                new URL(serverConfig.url),
-                {
-                  requestInit: {
-                    headers: serverConfig.headers,
-                  },
-                }
-              );
-              await client.connect(transport);
-            } catch {
-              // fallback to HTTP+SSE transport
-              await Promise.all([
-                client.close().catch(() => {}),
-                transport?.close().catch(() => {}),
-              ]);
-
-              transport = new SSEClientTransport(new URL(serverConfig.url), {
-                requestInit: {
-                  headers: serverConfig.headers,
-                },
-              });
-
-              client = new Client({
-                name: serverConfig.name,
-                version: "1.0.0",
-              });
-
-              await client.connect(transport);
-            } finally {
-              onCloseHooks.push(async () => {
-                await transport?.close();
-              });
-              onCloseHooks.push(() => client.close());
-            }
-          }
-
-          return [serverConfig.name, client];
-        })
-      )
-    );
-    // DONE SETTING UP CLIENTS
-
-    // SETUP SERVER
-
-    let externalToolNameMap = new Map<
-      string,
-      { serverName: string; toolName: string }
-    >();
-
-    let externalPromptNameMap = new Map<
-      string,
-      { serverName: string; promptName: string }
-    >();
-
-    // capabilities
-    const allSubCapabilities = clients.entries().map(([serverName, client]) => {
-      const subCapabilities = client.getServerCapabilities();
-
-      if (subCapabilities === undefined) {
-        return undefined;
-      }
-
-      const toolCapabilities: Required<
-        Required<ServerOptions>["capabilities"]
-      >["tools"] = Object.fromEntries(
-        Object.values(subCapabilities.tools ?? {}).flatMap((toolCapability) => {
-          if (typeof toolCapability !== "object") {
-            return [];
-          }
-          if (toolCapability === null) {
-            return [];
-          }
-          if (
-            "name" in toolCapability &&
-            typeof toolCapability.name === "string"
-          ) {
-            // make a unique name
-            const toolName = createUniqueName({
-              serverName,
-              name: toolCapability.name,
-              map: externalToolNameMap,
-            });
-
-            if (!toolName) {
-              return [];
-            }
-
-            externalToolNameMap.set(toolName, {
-              serverName,
-              toolName: toolCapability.name,
-            });
-
-            return [
-              [
-                toolName,
-                {
-                  ...toolCapability,
-                  name: toolName,
-                },
-              ],
-            ];
-          }
-
-          return [];
-        })
-      );
-
-      const promptCapabilities: Required<
-        Required<ServerOptions>["capabilities"]
-      >["prompts"] = Object.fromEntries(
-        Object.entries(subCapabilities.prompts ?? {}).flatMap(
-          (promptCapability) => {
-            if (typeof promptCapability !== "object") {
-              return [];
-            }
-            if (promptCapability === null) {
-              return [];
-            }
-            if (
-              "name" in promptCapability &&
-              typeof promptCapability.name === "string"
-            ) {
-              const promptName = createUniqueName({
-                serverName,
-                name: promptCapability.name,
-                map: externalPromptNameMap,
-              });
-
-              if (!promptName) {
-                return [];
-              }
-
-              externalPromptNameMap.set(promptName, {
-                serverName,
-                promptName: promptCapability.name,
-              });
-
-              return [
-                [
-                  promptName,
-                  {
-                    ...promptCapability,
-                    name: promptName,
-                  },
-                ],
-              ];
-            }
-
-            return [];
-          }
-        )
-      );
-
-      const resourceCapabilities: Required<
-        Required<ServerOptions>["capabilities"]
-      >["resources"] = Object.fromEntries(
-        Object.entries(subCapabilities.resources ?? {}).flatMap(
-          ([resourceCapabilityKey, resourceCapabilityValue]) => {
-            if (typeof resourceCapabilityValue !== "object") {
-              return [];
-            }
-            if (resourceCapabilityValue === null) {
-              return [];
-            }
-            if (
-              "uri" in resourceCapabilityValue &&
-              typeof resourceCapabilityValue.uri === "string"
-            ) {
-              return [
-                [
-                  wrapUriWithServer({
-                    serverName,
-                    uri: resourceCapabilityKey,
-                  }),
-                  {
-                    ...resourceCapabilityValue,
-                    uri: wrapUriWithServer({
-                      serverName,
-                      uri: resourceCapabilityValue.uri,
-                    }),
-                  },
-                ],
-              ];
-            }
-
-            return [];
-          }
-        )
-      );
-
-      return {
-        tools: subCapabilities.tools
-          ? {
-              ...toolCapabilities,
-              listChanged: subCapabilities.tools.listChanged,
-            }
-          : undefined,
-        prompts: subCapabilities.prompts
-          ? {
-              ...promptCapabilities,
-              listChanged: subCapabilities.prompts.listChanged,
-            }
-          : undefined,
-        resources: subCapabilities.resources
-          ? {
-              ...resourceCapabilities,
-              listChanged: subCapabilities.resources.listChanged,
-              subscribe: subCapabilities.resources.subscribe,
-            }
-          : undefined,
-      };
-    });
-
-    // instructions
-    const allInstructions: {
-      serverName: string;
-      instructions?: string;
-    }[] = Array.from(clients.entries()).map(([serverName, client]) => ({
-      serverName,
-      instructions: client.getInstructions(),
-    }));
-
-    const serverOptions: ServerOptions = {
-      capabilities: allSubCapabilities.reduce((acc, subCapabilities) => {
-        return {
-          tools: {
-            ...acc.tools,
-            ...(subCapabilities?.tools ?? {}),
-            listChanged:
-              acc.tools?.listChanged || subCapabilities?.tools?.listChanged,
-          },
-          prompts: {
-            ...acc.prompts,
-            ...(subCapabilities?.prompts ?? {}),
-            listChanged:
-              acc.prompts?.listChanged || subCapabilities?.prompts?.listChanged,
-          },
-          resources: {
-            ...acc.resources,
-            ...(subCapabilities?.resources ?? {}),
-            listChanged:
-              acc.resources?.listChanged ||
-              subCapabilities?.resources?.listChanged,
-            subscribe:
-              acc.resources?.subscribe || subCapabilities?.resources?.subscribe,
-          },
-        };
-      }, {} as Required<ServerOptions>["capabilities"]),
-      instructions:
-        "This is a proxy server that connects to other servers.\n\nProxied Servers:\n\n" +
-        allInstructions
-          .map(
-            ({ serverName, instructions }) =>
-              `# ${serverName}\n${instructions ?? ""}`
-          )
-          .join("\n\n"),
-    };
-
+    // SETUP WRAPPER SERVER
     const server = new McpServer(
       {
         name: "tool-connector",
         version: "1.0.0",
       },
-      serverOptions
+      {
+        capabilities: {
+          tools: {
+            listChanged: true,
+          },
+          prompts: {
+            listChanged: true,
+          },
+          resources: {
+            listChanged: true,
+            subscribe: true,
+          },
+          completions: {},
+          logging: {},
+        },
+        instructions:
+          "This is a proxy server that connects to other servers.\nProxied Servers:\n" +
+          (configs ?? []).map((config) => config.name).join("\n"),
+      }
     );
+    cleanupOnErrorHooks.push(() => server.close());
 
-    // request handlers
+    // WRAPPER SERVER REQUEST HANDLERS
+    // these are handlers for requests from the actual client to a wrapped MCP server
+    // i.e. from server to client since everything is reversed for us
     server.server.setRequestHandler(
       CallToolRequestSchema,
       (req): Promise<CallToolResult> => {
-        const internalTool = externalToolNameMap.get(req.params.name);
-
-        if (internalTool === undefined) {
-          throw new McpError(
-            ErrorCode.InvalidParams,
-            `Tool ${req.params.name} not found`
-          );
+        if (service === null) {
+          return new Promise((resolve, reject) => {
+            postInitHooks.push((s) =>
+              s.handleCallToolRequest(req).then(resolve).catch(reject)
+            );
+          });
+        } else {
+          return service.handleCallToolRequest(req);
         }
+      }
+    );
 
-        const client = clients.get(internalTool.serverName);
-        if (client === undefined) {
-          throw new McpError(
-            ErrorCode.InvalidParams,
-            `Tool ${req.params.name} not found`
-          );
+    server.server.setRequestHandler(
+      ListToolsRequestSchema,
+      async (req): Promise<ListToolsResult> => {
+        if (service === null) {
+          return new Promise((resolve, reject) => {
+            postInitHooks.push((s) =>
+              s.handleListToolsRequest(req).then(resolve).catch(reject)
+            );
+          });
+        } else {
+          return service.handleListToolsRequest(req);
         }
-
-        return client.callTool({
-          ...req.params,
-          name: internalTool.toolName,
-        }) as Promise<CallToolResult>;
       }
     );
 
     server.server.setRequestHandler(
       GetPromptRequestSchema,
       (req): Promise<GetPromptResult> => {
-        const internalPrompt = externalPromptNameMap.get(req.params.name);
-
-        if (internalPrompt === undefined) {
-          throw new McpError(
-            ErrorCode.InvalidParams,
-            `Prompt ${req.params.name} not found`
-          );
+        if (service === null) {
+          return new Promise((resolve, reject) => {
+            postInitHooks.push((s) =>
+              s.handleGetPromptRequest(req).then(resolve).catch(reject)
+            );
+          });
+        } else {
+          return service.handleGetPromptRequest(req);
         }
-
-        const client = clients.get(internalPrompt.serverName);
-
-        if (client === undefined) {
-          throw new McpError(
-            ErrorCode.InvalidParams,
-            `Prompt ${req.params.name} not found`
-          );
-        }
-
-        return client.getPrompt({
-          ...req.params,
-          name: internalPrompt.promptName,
-        });
-      }
-    );
-
-    server.server.setRequestHandler(
-      ReadResourceRequestSchema,
-      async (req): Promise<ReadResourceResult> => {
-        const { serverName, uri: resourceUri } = unwrapUri(req.params);
-
-        if (!serverName) {
-          throw new McpError(
-            ErrorCode.InvalidParams,
-            `Resource ${req.params.uri} not found`
-          );
-        }
-
-        const client = clients.get(serverName);
-
-        if (client === undefined) {
-          throw new McpError(
-            ErrorCode.InvalidParams,
-            `Resource ${req.params.uri} not found`
-          );
-        }
-
-        const result = await client.readResource({
-          ...req.params,
-          uri: resourceUri,
-        });
-
-        result.contents = result.contents.map((content) => ({
-          ...content,
-          uri: wrapUriWithServer({
-            serverName,
-            uri: content.uri,
-          }),
-        }));
-
-        return result;
-      }
-    );
-
-    server.server.setRequestHandler(
-      ListToolsRequestSchema,
-      async (): Promise<ListToolsResult> => {
-        const allTools: Tool[] = [];
-        const newToolMap: typeof externalToolNameMap = new Map();
-
-        for (const [serverName, client] of clients) {
-          try {
-            const { tools } = await client.listTools();
-
-            for (const tool of tools) {
-              const toolName = createUniqueName({
-                serverName,
-                name: tool.name,
-                map: newToolMap,
-              });
-
-              if (toolName) {
-                newToolMap.set(toolName, {
-                  serverName,
-                  toolName: tool.name,
-                });
-
-                allTools.push({
-                  ...tool,
-                  name: toolName,
-                });
-              }
-            }
-          } catch {
-            // ignore servers that do not support listing tools
-          }
-        }
-
-        externalToolNameMap = newToolMap;
-        return { tools: allTools };
       }
     );
 
     server.server.setRequestHandler(
       ListPromptsRequestSchema,
-      async (): Promise<ListPromptsResult> => {
-        const allPrompts: Prompt[] = [];
-        const newPromptMap: typeof externalPromptNameMap = new Map();
-
-        for (const [serverName, client] of clients) {
-          try {
-            const { prompts } = await client.listPrompts();
-
-            for (const prompt of prompts) {
-              const promptName = createUniqueName({
-                serverName,
-                name: prompt.name,
-                map: newPromptMap,
-              });
-
-              if (promptName) {
-                newPromptMap.set(promptName, {
-                  serverName,
-                  promptName: prompt.name,
-                });
-
-                allPrompts.push({
-                  ...prompt,
-                  name: promptName,
-                });
-              }
-            }
-          } catch {
-            // ignore servers that do not support listing prompts
-          }
+      async (req): Promise<ListPromptsResult> => {
+        if (service === null) {
+          return new Promise((resolve, reject) => {
+            postInitHooks.push((s) =>
+              s.handleListPromptsRequest(req).then(resolve).catch(reject)
+            );
+          });
+        } else {
+          return service.handleListPromptsRequest(req);
         }
-
-        externalPromptNameMap = newPromptMap;
-        return { prompts: allPrompts };
       }
     );
 
-    server.server.setRequestHandler(ListResourcesRequestSchema, () =>
-      handleListResources(clients)
+    // resource capabilities
+    server.server.setRequestHandler(
+      ReadResourceRequestSchema,
+      async (req): Promise<ReadResourceResult> => {
+        if (service === null) {
+          return new Promise((resolve, reject) => {
+            postInitHooks.push((s) =>
+              s.handleReadResourceRequest(req).then(resolve).catch(reject)
+            );
+          });
+        }
+        return service.handleReadResourceRequest(req);
+      }
     );
 
-    server.server.setRequestHandler(ListResourceTemplatesRequestSchema, () =>
-      handleListResourceTemplates(clients)
+    server.server.setRequestHandler(
+      ListResourcesRequestSchema,
+      (req): Promise<ListResourcesResult> => {
+        if (service === null) {
+          return new Promise((resolve, reject) => {
+            postInitHooks.push((s) =>
+              s.handleListResourcesRequest(req).then(resolve).catch(reject)
+            );
+          });
+        } else {
+          return service.handleListResourcesRequest(req);
+        }
+      }
     );
 
-    server.server.setRequestHandler(SubscribeRequestSchema, (req) => {
-      const { serverName, uri: resourceUri } = unwrapUri(req.params);
-
-      if (!serverName) {
-        throw new McpError(
-          ErrorCode.InvalidParams,
-          `Resource ${req.params.uri} not found`
-        );
+    server.server.setRequestHandler(
+      ListResourceTemplatesRequestSchema,
+      (req): Promise<ListResourceTemplatesResult> => {
+        if (service === null) {
+          return new Promise((resolve, reject) => {
+            postInitHooks.push((s) =>
+              s
+                .handleListResourceTemplatesRequest(req)
+                .then(resolve)
+                .catch(reject)
+            );
+          });
+        } else {
+          return service.handleListResourceTemplatesRequest(req);
+        }
       }
+    );
 
-      const client = clients.get(serverName);
-
-      if (client === undefined) {
-        throw new McpError(
-          ErrorCode.InvalidParams,
-          `Resource ${req.params.uri} not found`
-        );
+    server.server.setRequestHandler(
+      SubscribeRequestSchema,
+      (req): Promise<EmptyResult> => {
+        if (service === null) {
+          return new Promise((resolve, reject) => {
+            postInitHooks.push((s) =>
+              s.handleSubscribeRequest(req).then(resolve).catch(reject)
+            );
+          });
+        }
+        return service.handleSubscribeRequest(req);
       }
+    );
 
-      // silently ignore if the server does not support subscribing to resources
-      // unsure if there's a better way to handle this
-      if (!client.getServerCapabilities()?.resources?.subscribe) {
-        return {};
+    server.server.setRequestHandler(
+      UnsubscribeRequestSchema,
+      (req): Promise<EmptyResult> | EmptyResult => {
+        if (service === null) {
+          return new Promise((resolve, reject) => {
+            postInitHooks.push((s) =>
+              s.handleUnsubscribeRequest(req).then(resolve).catch(reject)
+            );
+          });
+        }
+        return service.handleUnsubscribeRequest(req);
       }
+    );
 
-      return client.subscribeResource({
-        ...req.params,
-        uri: resourceUri,
-      });
-    });
-
-    server.server.setRequestHandler(UnsubscribeRequestSchema, (req) => {
-      const { serverName, uri: resourceUri } = unwrapUri(req.params);
-
-      if (!serverName) {
-        throw new McpError(
-          ErrorCode.InvalidParams,
-          `Resource ${req.params.uri} not found`
-        );
+    // logging capabilities
+    server.server.setRequestHandler(
+      SetLevelRequestSchema,
+      (req): Promise<EmptyResult> => {
+        if (service === null) {
+          return new Promise((resolve, reject) => {
+            postInitHooks.push((s) =>
+              s.handleSetLevelRequest(req).then(resolve).catch(reject)
+            );
+          });
+        } else {
+          return service.handleSetLevelRequest(req);
+        }
       }
+    );
 
-      const client = clients.get(serverName);
-
-      if (client === undefined) {
-        throw new McpError(
-          ErrorCode.InvalidParams,
-          `Resource ${req.params.uri} not found`
-        );
+    // completions
+    server.server.setRequestHandler(
+      CompleteRequestSchema,
+      (req): Promise<CompleteResult> => {
+        if (service === null) {
+          return new Promise((resolve, reject) => {
+            postInitHooks.push((s) =>
+              s.handleCompleteRequest(req).then(resolve).catch(reject)
+            );
+          });
+        } else {
+          return service.handleCompleteRequest(req);
+        }
       }
-
-      // silently ignore if the server does not support subscribing to resources
-      // unsure if there's a better way to handle this
-      if (!client.getServerCapabilities()?.resources?.subscribe) {
-        return {};
-      }
-
-      return client.unsubscribeResource({
-        ...req.params,
-        uri: resourceUri,
-      });
-    });
+    );
+    // END WRAPPER SERVER REQUEST HANDLERS
 
     server.server.setNotificationHandler(
-      RootsListChangedNotificationSchema,
-      () =>
-        Promise.all(
-          Array.from(clients.values()).map((client) =>
-            client.sendRootsListChanged().catch(() => {})
-          )
-        ).then(() => {})
+      ProgressNotificationSchema,
+      (notification) => {
+        if (service === null) {
+          return new Promise((resolve, reject) => {
+            postInitHooks.push((s) =>
+              s
+                .handleProgressNotification(notification)
+                .then(resolve)
+                .catch(reject)
+            );
+          });
+        } else {
+          return service.handleProgressNotification(notification);
+        }
+      }
     );
+    // END WRAPPER SERVER NOTIFICATION HANDLERS
 
-    // notifications
-    for (const [serverName, client] of clients) {
-      client.setNotificationHandler(
-        ProgressNotificationSchema,
-        (notification) => server.server.notification(notification)
+    // WRAPPER SERVER POST-INITIALIZATION
+    const defaultEnv = getDefaultEnvironment();
+    server.server.oninitialized = async () => {
+      // we need to wait until after the wrapper server connects to the actual client
+      // to properly advertize capabilities and prevent requests from coming too soon
+
+      const clientCapabilities = server.server.getClientCapabilities();
+      const clientVersion = server.server.getClientVersion();
+
+      const clients = new Map(
+        (
+          await Promise.all(
+            (configs ?? [])
+              .map(async (serverConfig): Promise<[string, Client]> => {
+                let client = new Client(
+                  clientVersion ?? {
+                    name: "tool-connector",
+                    version: "1.0.0",
+                  },
+                  {
+                    capabilities: {
+                      roots: clientCapabilities?.roots
+                        ? {
+                            listChanged: clientCapabilities.roots.listChanged,
+                          }
+                        : undefined,
+                      sampling: clientCapabilities?.sampling ? {} : undefined,
+                    },
+                  }
+                );
+
+                if (serverConfig.kind === "command") {
+                  cleanupOnErrorHooks.push(() => client.close());
+
+                  const transport = new StdioClientTransport({
+                    command: serverConfig.command,
+                    args: serverConfig.args,
+                    env: {
+                      ...defaultEnv,
+                      ...serverConfig.env,
+                    },
+                  });
+                  await client.connect(transport);
+                } else {
+                  // try Streamable HTTP transport first
+                  let transport:
+                    | StreamableHTTPClientTransport
+                    | SSEClientTransport
+                    | null = null;
+                  try {
+                    transport = new StreamableHTTPClientTransport(
+                      new URL(serverConfig.url),
+                      {
+                        requestInit: {
+                          headers: serverConfig.headers,
+                        },
+                      }
+                    );
+                    await client.connect(transport);
+                  } catch {
+                    // fallback to HTTP+SSE transport
+                    transport = new SSEClientTransport(
+                      new URL(serverConfig.url),
+                      {
+                        requestInit: {
+                          headers: serverConfig.headers,
+                        },
+                      }
+                    );
+
+                    client = new Client(
+                      clientVersion ?? {
+                        name: "tool-connector",
+                        version: "1.0.0",
+                      },
+                      {
+                        capabilities: {
+                          roots: clientCapabilities?.roots
+                            ? {
+                                listChanged:
+                                  clientCapabilities.roots.listChanged,
+                              }
+                            : undefined,
+                          sampling: clientCapabilities?.sampling
+                            ? {}
+                            : undefined,
+                        },
+                      }
+                    );
+
+                    await client.connect(transport);
+                  } finally {
+                    cleanupOnErrorHooks.push(() => client.close());
+                  }
+                }
+
+                return [serverConfig.name, client];
+              })
+              .map((promise, index) =>
+                promise.catch((error) => {
+                  console.error(
+                    `Failed to connect to an MCP server [${
+                      configs?.[index]?.name ?? "unknown"
+                    }]: ${error}`
+                  );
+
+                  // skip servers that don't work
+                  return null;
+                })
+              )
+          )
+        ).filter(G.isNotNullable)
       );
 
-      client.setNotificationHandler(
-        CancelledNotificationSchema,
-        (notification) => server.server.notification(notification)
-      );
+      // WRAPPED SERVER HANDLERS
+      // these are handlers for requests and notifications from the wrapped MCP servers to the actual client
+      // i.e. from client to server since everything is reversed for us
+      for (const [serverName, client] of clients) {
+        // wrapped MCP server to actual client notifications
+        const subCapabilities = client.getServerCapabilities();
 
-      const subCapabilities = client.getServerCapabilities();
-      if (subCapabilities?.tools?.listChanged) {
-        client.setNotificationHandler(ToolListChangedNotificationSchema, () =>
-          server.sendToolListChanged()
-        );
-      }
-
-      if (subCapabilities?.prompts?.listChanged) {
-        client.setNotificationHandler(PromptListChangedNotificationSchema, () =>
-          server.sendPromptListChanged()
-        );
-      }
-
-      if (subCapabilities?.resources?.listChanged) {
         client.setNotificationHandler(
-          ResourceListChangedNotificationSchema,
-          () => server.sendResourceListChanged()
-        );
-      }
-
-      if (subCapabilities?.resources?.subscribe) {
-        client.setNotificationHandler(
-          ResourceUpdatedNotificationSchema,
+          ProgressNotificationSchema,
           (notification) =>
-            server.server.sendResourceUpdated({
-              ...notification.params,
-              uri: wrapUriWithServer({
-                serverName,
-                uri: notification.params.uri,
-              }),
+            server.server.notification({
+              ...notification,
+              params: notification.params
+                ? {
+                    ...notification.params,
+                    progressToken: unwrapProgressToken({
+                      progressToken: notification.params.progressToken,
+                    }).progressToken,
+                  }
+                : notification.params,
             })
         );
+
+        if (subCapabilities?.tools?.listChanged) {
+          client.setNotificationHandler(ToolListChangedNotificationSchema, () =>
+            server.sendToolListChanged()
+          );
+        }
+
+        if (subCapabilities?.prompts?.listChanged) {
+          client.setNotificationHandler(
+            PromptListChangedNotificationSchema,
+            () => server.sendPromptListChanged()
+          );
+        }
+
+        if (subCapabilities?.resources?.listChanged) {
+          client.setNotificationHandler(
+            ResourceListChangedNotificationSchema,
+            () => server.sendResourceListChanged()
+          );
+        }
+
+        if (subCapabilities?.resources?.subscribe) {
+          client.setNotificationHandler(
+            ResourceUpdatedNotificationSchema,
+            (notification) =>
+              server.server.sendResourceUpdated({
+                ...notification.params,
+                uri: wrapUriWithServer({
+                  serverName,
+                  uri: notification.params.uri,
+                }),
+              })
+          );
+        }
+
+        // wrapped MCP server to actual client requests
+        if (clientCapabilities?.sampling) {
+          client.setRequestHandler(
+            CreateMessageRequestSchema,
+            (req): Promise<CreateMessageResult> => {
+              if (!server.isConnected()) {
+                throw new McpError(
+                  ErrorCode.ConnectionClosed,
+                  "Client is not connected"
+                );
+              }
+
+              return server.server.createMessage(req.params);
+            }
+          );
+        }
+
+        if (clientCapabilities?.roots) {
+          client.setRequestHandler(
+            ListRootsRequestSchema,
+            async (req): Promise<ListRootsResult> => {
+              if (!server.isConnected()) {
+                throw new McpError(
+                  ErrorCode.ConnectionClosed,
+                  "Client is not connected"
+                );
+              }
+
+              const roots = await server.server.listRoots(req.params);
+
+              // wrap URIs with server name
+              return {
+                roots: roots.roots.map((root) => ({
+                  ...root,
+                  uri: wrapUriWithServer({
+                    serverName,
+                    uri: root.uri,
+                  }),
+                })),
+              };
+            }
+          );
+        }
       }
-    }
+
+      const ensuredService = new WrapperService(clients);
+
+      cleanupOnErrorHooks.push(() => ensuredService.close());
+
+      service = ensuredService;
+
+      // POST INIT WRAPPER SERVER HANDLERS
+      // these handlers are only set post-init
+      if (clientCapabilities?.roots?.listChanged) {
+        server.server.setNotificationHandler(
+          RootsListChangedNotificationSchema,
+          (notification) =>
+            ensuredService.handleRootsListChangedNotification(notification)
+        );
+      }
+      // END POST INIT WRAPPER SERVER HANDLERS
+
+      if (!postInitHooksCalled) {
+        postInitHooksCalled = true;
+        await Promise.all(
+          postInitHooks.map((hook) => hook(ensuredService).catch(() => {}))
+        );
+      }
+      // END WRAPPED SERVER HANDLERS
+    };
+    // END WRAPPER SERVER POST-INITIALIZATION
 
     // cleanup hooks
     server.server.onclose = () => {
-      Promise.all(onCloseHooks.map((hook) => hook().catch(() => {})));
+      service?.close();
     };
 
-    // DONE SETTING UP SERVER
+    // DONE SETTING UP WRAPPER SERVER
 
     return server;
   } catch (error) {
     // Clean up any clients that were created before the error occurred
-    await Promise.all(onCloseHooks.map((hook) => hook().catch(() => {})));
+    await Promise.all(
+      cleanupOnErrorHooks.map((hook) => hook().catch(() => {}))
+    );
     throw error;
   }
 }

--- a/src/main/mcp/wrapper-service.ts
+++ b/src/main/mcp/wrapper-service.ts
@@ -1,0 +1,749 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import {
+  CallToolRequest,
+  CallToolResult,
+  CompleteRequest,
+  CompleteResult,
+  EmptyResult,
+  ErrorCode,
+  GetPromptRequest,
+  GetPromptResult,
+  ListPromptsRequest,
+  ListPromptsResult,
+  ListResourcesRequest,
+  ListResourcesResult,
+  ListResourceTemplatesRequest,
+  ListResourceTemplatesResult,
+  ListToolsRequest,
+  ListToolsResult,
+  McpError,
+  ProgressNotification,
+  Prompt,
+  ReadResourceRequest,
+  ReadResourceResult,
+  RootsListChangedNotification,
+  SetLevelRequest,
+  SubscribeRequest,
+  Tool,
+  UnsubscribeRequest,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  unwrapProgressToken,
+  unwrapUri,
+  wrapProgressTokenWithServer,
+  wrapUriWithServer,
+} from "./conversion";
+
+const MAX_NAME_LENGTH = 64;
+
+function createUniqueName({
+  serverName,
+  name,
+  map,
+}: {
+  serverName: string;
+  name: string;
+  map: Map<string, unknown>;
+}): string | null {
+  // make a unique name
+  let uniqueName = `${serverName}-${name}`.substring(0, MAX_NAME_LENGTH);
+
+  let i = 1;
+  while (map.has(uniqueName)) {
+    // this is kind of ridiculous
+    if (i > 16) {
+      return null;
+    }
+
+    uniqueName = name + i;
+
+    // cut from the front to make sure that i isn't cut off
+    if (uniqueName.length > MAX_NAME_LENGTH) {
+      uniqueName = uniqueName.substring(uniqueName.length - MAX_NAME_LENGTH);
+    }
+
+    i++;
+  }
+
+  return uniqueName;
+}
+
+/**
+ * This service proxies requests to all the wrapped MCP servers.
+ *
+ * This service should only be created after a connection is established with the actual client
+ * and all wrapped MCP servers are initialized.
+ *
+ * TODO: support cancellation
+ */
+export default class WrapperService {
+  isClosed = false;
+
+  private externalToolNameMap: Map<
+    string,
+    { serverName: string; toolName: string }
+  > | null = null;
+
+  private externalPromptNameMap: Map<
+    string,
+    { serverName: string; promptName: string }
+  > | null = null;
+
+  constructor(private clients: Map<string, Client>) {}
+
+  async close(): Promise<void> {
+    if (this.isClosed) {
+      return;
+    }
+
+    this.isClosed = true;
+    await Promise.all(
+      Array.from(this.clients.values()).map((client) => client.close())
+    );
+  }
+
+  async handleCallToolRequest(req: CallToolRequest): Promise<CallToolResult> {
+    if (this.isClosed) {
+      throw new McpError(ErrorCode.ConnectionClosed, "Client is closed");
+    }
+
+    if (this.externalToolNameMap === null) {
+      const { externalToolNameMap: newToolMap } = await this.listAllTools();
+      this.externalToolNameMap = newToolMap;
+    }
+
+    const internalTool = this.externalToolNameMap.get(req.params.name);
+
+    if (internalTool === undefined) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Tool ${req.params.name} not found`
+      );
+    }
+
+    const client = this.clients.get(internalTool.serverName);
+    if (client === undefined) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Tool ${req.params.name} not found`
+      );
+    }
+
+    const res = await client.callTool({
+      ...req.params,
+      name: internalTool.toolName,
+      _meta:
+        req.params._meta?.progressToken !== undefined
+          ? {
+              ...req.params._meta,
+              progressToken: wrapProgressTokenWithServer({
+                serverName: internalTool.serverName,
+                progressToken: req.params._meta.progressToken,
+              }),
+            }
+          : req.params._meta,
+    });
+
+    return res as CallToolResult;
+  }
+
+  private async listAllTools(): Promise<{
+    tools: Tool[];
+    externalToolNameMap: Map<string, { serverName: string; toolName: string }>;
+  }> {
+    if (this.isClosed) {
+      throw new McpError(ErrorCode.ConnectionClosed, "Client is closed");
+    }
+
+    const allTools: Tool[] = [];
+    const newToolMap: Map<string, { serverName: string; toolName: string }> =
+      new Map();
+
+    for (const [serverName, client] of this.clients) {
+      // skip servers that do not support tools
+      if (!client.getServerCapabilities()?.tools) {
+        continue;
+      }
+
+      try {
+        const { tools, nextCursor } = await client.listTools();
+
+        if (nextCursor) {
+          // TODO: handle pagination
+          console.log(
+            `Server ${serverName} paginates tools, which is not yet supported.`
+          );
+        }
+
+        for (const tool of tools) {
+          const toolName = createUniqueName({
+            serverName,
+            name: tool.name,
+            map: newToolMap,
+          });
+
+          if (toolName) {
+            newToolMap.set(toolName, {
+              serverName,
+              toolName: tool.name,
+            });
+
+            allTools.push({
+              ...tool,
+              name: toolName,
+            });
+          }
+        }
+      } catch (error) {
+        console.error(`Failed to list tools for server ${serverName}:`, error);
+      }
+    }
+
+    return { tools: allTools, externalToolNameMap: newToolMap };
+  }
+
+  async handleListToolsRequest(
+    _req: ListToolsRequest
+  ): Promise<ListToolsResult> {
+    // TODO: support progress
+    const { tools, externalToolNameMap: newToolMap } =
+      await this.listAllTools();
+
+    this.externalToolNameMap = newToolMap;
+
+    return { tools };
+  }
+
+  async handleGetPromptRequest(
+    req: GetPromptRequest
+  ): Promise<GetPromptResult> {
+    if (this.isClosed) {
+      throw new McpError(ErrorCode.ConnectionClosed, "Client is closed");
+    }
+
+    if (this.externalPromptNameMap === null) {
+      const { externalPromptNameMap: newPromptMap } =
+        await this.listAllPrompts();
+      this.externalPromptNameMap = newPromptMap;
+    }
+
+    const internalPrompt = this.externalPromptNameMap.get(req.params.name);
+
+    if (internalPrompt === undefined) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Prompt ${req.params.name} not found`
+      );
+    }
+
+    const client = this.clients.get(internalPrompt.serverName);
+
+    if (client === undefined || !client.getServerCapabilities()?.prompts) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Prompt ${req.params.name} not found`
+      );
+    }
+
+    return client.getPrompt({
+      ...req.params,
+      name: internalPrompt.promptName,
+      _meta:
+        req.params._meta?.progressToken !== undefined
+          ? {
+              ...req.params._meta,
+              progressToken: wrapProgressTokenWithServer({
+                serverName: internalPrompt.serverName,
+                progressToken: req.params._meta.progressToken,
+              }),
+            }
+          : req.params._meta,
+    });
+  }
+
+  async listAllPrompts(): Promise<{
+    prompts: Prompt[];
+    externalPromptNameMap: Map<
+      string,
+      { serverName: string; promptName: string }
+    >;
+  }> {
+    if (this.isClosed) {
+      throw new McpError(ErrorCode.ConnectionClosed, "Client is closed");
+    }
+
+    const allPrompts: Prompt[] = [];
+    const newPromptMap: Map<
+      string,
+      { serverName: string; promptName: string }
+    > = new Map();
+
+    for (const [serverName, client] of this.clients) {
+      // skip servers that do not support prompts
+      if (!client.getServerCapabilities()?.prompts) {
+        continue;
+      }
+
+      try {
+        const { prompts, nextCursor } = await client.listPrompts();
+
+        if (nextCursor) {
+          // TODO: handle pagination
+          console.log(
+            `Server ${serverName} paginates prompts, which is not yet supported.`
+          );
+        }
+
+        for (const prompt of prompts) {
+          const promptName = createUniqueName({
+            serverName,
+            name: prompt.name,
+            map: newPromptMap,
+          });
+
+          if (promptName) {
+            newPromptMap.set(promptName, {
+              serverName,
+              promptName: prompt.name,
+            });
+
+            allPrompts.push({
+              ...prompt,
+              name: promptName,
+            });
+          }
+        }
+      } catch (error) {
+        console.error(
+          `Failed to list prompts for server ${serverName}:`,
+          error
+        );
+      }
+    }
+    return { prompts: allPrompts, externalPromptNameMap: newPromptMap };
+  }
+
+  async handleListPromptsRequest(
+    _req: ListPromptsRequest
+  ): Promise<ListPromptsResult> {
+    // TODO: support progress
+    const { prompts, externalPromptNameMap: newPromptMap } =
+      await this.listAllPrompts();
+
+    this.externalPromptNameMap = newPromptMap;
+
+    return { prompts };
+  }
+
+  async handleReadResourceRequest(
+    req: ReadResourceRequest
+  ): Promise<ReadResourceResult> {
+    if (this.isClosed) {
+      throw new McpError(ErrorCode.ConnectionClosed, "Client is closed");
+    }
+
+    const { serverName, uri: resourceUri } = unwrapUri(req.params);
+
+    if (!serverName) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Resource ${req.params.uri} not found`
+      );
+    }
+
+    const client = this.clients.get(serverName);
+
+    if (client === undefined || !client.getServerCapabilities()?.resources) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Resource ${req.params.uri} not found`
+      );
+    }
+
+    const result = await client.readResource({
+      ...req.params,
+      uri: resourceUri,
+      _meta:
+        req.params._meta?.progressToken !== undefined
+          ? {
+              ...req.params._meta,
+              progressToken: wrapProgressTokenWithServer({
+                serverName,
+                progressToken: req.params._meta.progressToken,
+              }),
+            }
+          : req.params._meta,
+    });
+
+    result.contents = result.contents.map((content) => ({
+      ...content,
+      uri: wrapUriWithServer({
+        serverName,
+        uri: content.uri,
+      }),
+    }));
+
+    return result;
+  }
+
+  async handleListResourcesRequest(
+    _req: ListResourcesRequest
+  ): Promise<ListResourcesResult> {
+    if (this.isClosed) {
+      throw new McpError(ErrorCode.ConnectionClosed, "Client is closed");
+    }
+
+    // todo: support progress
+
+    return {
+      resources: (
+        await Promise.all(
+          Array.from(this.clients.entries()).flatMap(
+            async ([serverName, client]) => {
+              // skip servers that do not support resources
+              if (!client.getServerCapabilities()?.resources) {
+                return [];
+              }
+
+              try {
+                const { resources, nextCursor } = await client.listResources();
+
+                if (nextCursor) {
+                  // TODO: handle pagination
+                  console.log(
+                    `Server ${serverName} paginates resources, which is not yet supported.`
+                  );
+                }
+
+                return resources.map((resource) => ({
+                  ...resource,
+                  uri: wrapUriWithServer({
+                    serverName,
+                    uri: resource.uri,
+                  }),
+                }));
+              } catch (error) {
+                console.error(
+                  `Failed to list resources for server ${serverName}:`,
+                  error
+                );
+                return [];
+              }
+            }
+          )
+        )
+      ).flat(),
+    };
+  }
+
+  async handleListResourceTemplatesRequest(
+    _req: ListResourceTemplatesRequest
+  ): Promise<ListResourceTemplatesResult> {
+    if (this.isClosed) {
+      throw new McpError(ErrorCode.ConnectionClosed, "Client is closed");
+    }
+
+    // todo: support progress
+
+    return {
+      resourceTemplates: (
+        await Promise.all(
+          Array.from(this.clients.entries()).flatMap(
+            async ([serverName, client]) => {
+              // skip servers that do not support resources
+              if (!client.getServerCapabilities()?.resources) {
+                return [];
+              }
+
+              try {
+                const { resourceTemplates, nextCursor } =
+                  await client.listResourceTemplates();
+
+                if (nextCursor) {
+                  // TODO: handle pagination
+                  console.log(
+                    `Server ${serverName} paginates resource templates, which is not yet supported.`
+                  );
+                }
+
+                return resourceTemplates.map((template) => ({
+                  ...template,
+                  uriTemplate: wrapUriWithServer({
+                    serverName,
+                    uri: template.uriTemplate,
+                  }),
+                }));
+              } catch (error) {
+                console.error(
+                  `Failed to list resource templates for server ${serverName}:`,
+                  error
+                );
+                return [];
+              }
+            }
+          )
+        )
+      ).flat(),
+    };
+  }
+
+  async handleSubscribeRequest(req: SubscribeRequest): Promise<EmptyResult> {
+    if (this.isClosed) {
+      throw new McpError(ErrorCode.ConnectionClosed, "Client is closed");
+    }
+
+    const { serverName, uri: resourceUri } = unwrapUri(req.params);
+
+    if (!serverName) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Resource ${req.params.uri} not found`
+      );
+    }
+
+    const client = this.clients.get(serverName);
+
+    if (client === undefined) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Resource ${req.params.uri} not found`
+      );
+    }
+
+    // silently ignore if the server does not support subscribing to resources
+    // unsure if there's a better way to handle this
+    if (!client.getServerCapabilities()?.resources?.subscribe) {
+      return {};
+    }
+
+    return client.subscribeResource({
+      ...req.params,
+      uri: resourceUri,
+      _meta:
+        req.params._meta?.progressToken !== undefined
+          ? {
+              ...req.params._meta,
+              progressToken: wrapProgressTokenWithServer({
+                serverName,
+                progressToken: req.params._meta.progressToken,
+              }),
+            }
+          : req.params._meta,
+    });
+  }
+
+  async handleUnsubscribeRequest(
+    req: UnsubscribeRequest
+  ): Promise<EmptyResult> {
+    if (this.isClosed) {
+      throw new McpError(ErrorCode.ConnectionClosed, "Client is closed");
+    }
+
+    const { serverName, uri: resourceUri } = unwrapUri(req.params);
+
+    if (!serverName) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Resource ${req.params.uri} not found`
+      );
+    }
+
+    const client = this.clients.get(serverName);
+
+    if (client === undefined) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        `Resource ${req.params.uri} not found`
+      );
+    }
+
+    // silently ignore if the server does not support subscribing to resources
+    // unsure if there's a better way to handle this
+    if (!client.getServerCapabilities()?.resources?.subscribe) {
+      return {};
+    }
+
+    return client.unsubscribeResource({
+      ...req.params,
+      uri: resourceUri,
+      _meta:
+        req.params._meta?.progressToken !== undefined
+          ? {
+              ...req.params._meta,
+              progressToken: wrapProgressTokenWithServer({
+                serverName,
+                progressToken: req.params._meta.progressToken,
+              }),
+            }
+          : req.params._meta,
+    });
+  }
+
+  async handleSetLevelRequest(req: SetLevelRequest): Promise<EmptyResult> {
+    if (this.isClosed) {
+      throw new McpError(ErrorCode.ConnectionClosed, "Client is closed");
+    }
+
+    await Promise.all(
+      Array.from(this.clients.entries()).map(([serverName, client]) => {
+        if (!client.getServerCapabilities()?.logging) {
+          return;
+        }
+        return client.setLoggingLevel(req.params.level).catch((error) => {
+          console.error(
+            `Failed to set logging level for server ${serverName}:`,
+            error
+          );
+        });
+      })
+    );
+    return {};
+  }
+
+  async handleCompleteRequest(req: CompleteRequest): Promise<CompleteResult> {
+    if (this.isClosed) {
+      throw new McpError(ErrorCode.ConnectionClosed, "Client is closed");
+    }
+
+    if (req.params.ref.type === "ref/prompt") {
+      if (this.externalPromptNameMap === null) {
+        const { externalPromptNameMap: newPromptMap } =
+          await this.listAllPrompts();
+        this.externalPromptNameMap = newPromptMap;
+      }
+
+      const internalPrompt = this.externalPromptNameMap.get(
+        req.params.ref.name
+      );
+
+      if (internalPrompt === undefined) {
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          `Prompt ${req.params.ref.name} not found`
+        );
+      }
+
+      const client = this.clients.get(internalPrompt.serverName);
+
+      if (client === undefined || !client.getServerCapabilities()?.prompts) {
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          `Prompt ${req.params.ref.name} not found`
+        );
+      }
+
+      return client.complete({
+        ...req.params,
+        _meta:
+          req.params._meta?.progressToken !== undefined
+            ? {
+                ...req.params._meta,
+                progressToken: wrapProgressTokenWithServer({
+                  serverName: internalPrompt.serverName,
+                  progressToken: req.params._meta.progressToken,
+                }),
+              }
+            : req.params._meta,
+      });
+    } else if (req.params.ref.type === "ref/resource") {
+      const { serverName, uri: resourceUri } = unwrapUri(req.params.ref);
+
+      if (!serverName) {
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          `Resource ${req.params.ref.uri} not found`
+        );
+      }
+
+      const client = this.clients.get(serverName);
+
+      if (client === undefined || !client.getServerCapabilities()?.resources) {
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          `Resource ${req.params.ref.uri} not found`
+        );
+      }
+
+      return client.complete({
+        ...req.params,
+        ref: {
+          ...req.params.ref,
+          uri: resourceUri,
+        },
+        _meta:
+          req.params._meta?.progressToken !== undefined
+            ? {
+                ...req.params._meta,
+                progressToken: wrapProgressTokenWithServer({
+                  serverName,
+                  progressToken: req.params._meta.progressToken,
+                }),
+              }
+            : req.params._meta,
+      });
+    }
+
+    req.params.ref satisfies never;
+    throw new McpError(ErrorCode.InvalidParams, "Invalid reference type");
+  }
+
+  async handleRootsListChangedNotification(
+    _notification: RootsListChangedNotification
+  ): Promise<void> {
+    if (this.isClosed) {
+      return;
+    }
+
+    await Promise.all(
+      Array.from(this.clients.entries()).map(([serverName, client]) => {
+        if (!client.getServerCapabilities()?.resources) {
+          return;
+        }
+
+        client.sendRootsListChanged().catch((error) => {
+          console.error(
+            `Failed to send roots list changed notification for server ${serverName}:`,
+            error
+          );
+        });
+      })
+    );
+  }
+
+  async handleProgressNotification(
+    notification: ProgressNotification
+  ): Promise<void> {
+    if (this.isClosed) {
+      return;
+    }
+
+    const { serverName, progressToken } = unwrapProgressToken({
+      progressToken: notification.params.progressToken,
+    });
+
+    // ok to ignore
+    if (!serverName) {
+      return;
+    }
+
+    const client = this.clients.get(serverName);
+
+    // ok to ignore
+    if (client === undefined) {
+      return;
+    }
+
+    client.notification({
+      ...notification,
+      params: notification.params
+        ? {
+            ...notification.params,
+            progressToken: wrapProgressTokenWithServer({
+              serverName,
+              progressToken,
+            }),
+          }
+        : notification.params,
+    });
+  }
+}


### PR DESCRIPTION
fixes

1. properly notify wrapped mcp servers of client capabilities
2. notify the client that the wrapper server has all capabilities we can potentially support (ignore requests when the underlying server doesn't support them)
3. implement sampling, completion, and client-to-server progress notifications
4. properly forward progress tokens
5. remove cancellation support since i don't think the MCP client typescript SDK provides [the json rpc request id that you need to cancel a request](https://modelcontextprotocol.io/specification/2025-03-26/basic/utilities/cancellation)

the create wrapper mcp server flow now looks like this

1. client initializes a session with tool-connector
2. tool-connector establishes the connection with the client
3. any requests and notifications from the client are queued in-memory by tool-connector
4. tool-connector gets client capabilities to forward to the mcp servers
5. tool-connector initializes all the mcp servers from configs
6. tool-connector creates WrapperService to handle all messages being sent to the mcp servers and starts handling live requests as they come from the client
7. tool-connector flushes its request / notification backlog (possibly out-of-order)