### PR TITLE
Fix regex for MCP server name validation

### DIFF
--- a/src/renderer/app/configs-editor/index.tsx
+++ b/src/renderer/app/configs-editor/index.tsx
@@ -67,7 +67,7 @@ function ConfigsEditor() {
     let hasError = false;
 
     for (const [index, mcpServer] of values.mcp_servers.entries()) {
-      const serverName = mcpServer.name.replaceAll(/[^a-zA-Z0-0_-]/g, "");
+      const serverName = mcpServer.name.replaceAll(/[^a-zA-Z0-9_-]/g, "");
 
       if (serverName.length === 0) {
         form.setError(


### PR DESCRIPTION
## Summary
- fix MCP server name validation regex to allow digits 0-9

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e24e0ed8083258b2fd02f890b3ca1