### PR TITLE
Fix error label color class

### DIFF
--- a/src/renderer/app/configs-editor/mcp-server-form-field.tsx
+++ b/src/renderer/app/configs-editor/mcp-server-form-field.tsx
@@ -206,7 +206,7 @@ export default function McpServerFormField({
                     <div className="flex flex-col gap-2">
                       <label
                         className={cn("text-sm font-medium", {
-                          "test-red-500": !!typeCastedErrors?.env?.message,
+                          "text-red-500": !!typeCastedErrors?.env?.message,
                         })}
                       >
                         Environment Variables
@@ -331,7 +331,7 @@ export default function McpServerFormField({
                     <div className="flex flex-col gap-2">
                       <label
                         className={cn("text-sm font-medium", {
-                          "test-red-500": !!typeCastedErrors?.headers?.message,
+                          "text-red-500": !!typeCastedErrors?.headers?.message,
                         })}
                       >
                         Headers


### PR DESCRIPTION
## Summary
- fix typo in error label color class in MCP server form field

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e25f6bfbc832591c45ab1ac89fe9c