### PR TITLE
Fix comment spelling

### DIFF
--- a/src/main/mcp/create-wrapper-mcp-server.ts
+++ b/src/main/mcp/create-wrapper-mcp-server.ts
@@ -284,7 +284,7 @@ export default async function createWrapperMcpServer({
     const defaultEnv = getDefaultEnvironment();
     server.server.oninitialized = async () => {
       // we need to wait until after the wrapper server connects to the actual client
-      // to properly advertize capabilities and prevent requests from coming too soon
+      // to properly advertise capabilities and prevent requests from coming too soon
 
       const clientCapabilities = server.server.getClientCapabilities();
       const clientVersion = server.server.getClientVersion();


### PR DESCRIPTION
## Summary
- fix a typo in `create-wrapper-mcp-server.ts` comment

## Testing
- `npm run test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_685e25f8f9a08325a6ceb80f479cff41