### PR TITLE
Add tests for URI conversion helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "electron-forge start",
     "package": "electron-forge package",
     "make": "electron-forge make",
-    "publish": "electron-forge publish"
+    "publish": "electron-forge publish",
+    "test": "node --import ts-node/register --import tsconfig-paths/register.js --loader ts-node/esm --test test/conversion.test.ts"
   },
   "keywords": [],
   "author": "charlotte",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "package": "electron-forge package",
     "make": "electron-forge make",
     "publish": "electron-forge publish",
-    "test": "node --import ts-node/register --import tsconfig-paths/register.js --loader ts-node/esm --test test/conversion.test.ts"
+    "test": "node --import ts-node/register --import tsconfig-paths/register.js --loader ts-node/esm --test \"test/**/*.test.ts\" \"test/**/*.test.js\" \"test/**/*.spec.ts\" \"test/**/*.spec.js\""
   },
   "keywords": [],
   "author": "charlotte",

--- a/test/conversion.test.js
+++ b/test/conversion.test.js
@@ -1,0 +1,31 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { wrapUriWithServer, unwrapUri } = require('../src/main/mcp/conversion.ts');
+
+const serverName = 'myServer';
+const originalUri = 'https://example.com/path';
+
+test('wrapUriWithServer and unwrapUri round-trip', () => {
+  const wrapped = wrapUriWithServer({ serverName, uri: originalUri });
+  const unwrapped = unwrapUri({ uri: wrapped });
+  assert.equal(unwrapped.serverName, serverName);
+  assert.equal(unwrapped.uri, originalUri);
+});
+
+test('wrapUriWithServer leaves invalid URI unchanged', () => {
+  const invalidUri = 'not-a-uri';
+  const wrapped = wrapUriWithServer({ serverName, uri: invalidUri });
+  assert.equal(wrapped, invalidUri);
+});
+
+test('unwrapUri returns input for invalid URI', () => {
+  const invalidUri = 'not-a-uri';
+  const result = unwrapUri({ uri: invalidUri });
+  assert.deepEqual(result, { uri: invalidUri });
+});
+
+test('unwrapUri returns input when no server prefix is present', () => {
+  const uriWithoutServer = 'https://domain-only';
+  const result = unwrapUri({ uri: uriWithoutServer });
+  assert.deepEqual(result, { uri: uriWithoutServer });
+});

--- a/test/conversion.test.ts
+++ b/test/conversion.test.ts
@@ -1,6 +1,6 @@
-const test = require('node:test');
-const assert = require('node:assert/strict');
-const { wrapUriWithServer, unwrapUri } = require('../src/main/mcp/conversion.ts');
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { wrapUriWithServer, unwrapUri } from '@/main/mcp/conversion';
 
 const serverName = 'myServer';
 const originalUri = 'https://example.com/path';


### PR DESCRIPTION
## Summary
- add round-trip tests for wrapUriWithServer/unwrapUri

## Testing
- `node --import ts-node/register --test test/conversion.test.js`

------
https://chatgpt.com/codex/tasks/task_e_685e25fc492c8325abc7b6f7e441f033